### PR TITLE
Update for Stardew Valley 1.6

### DIFF
--- a/GiftTasteHelper.sln
+++ b/GiftTasteHelper.sln
@@ -1,9 +1,9 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GiftTasteHelper", "GiftTasteHelper\GiftTasteHelper.csproj", "{CA415B12-5C37-487A-92BE-0AED14440F36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GiftTasteHelper", "GiftTasteHelper\GiftTasteHelper.csproj", "{CA415B12-5C37-487A-92BE-0AED14440F36}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/GiftTasteHelper/Framework/Controllers/GiftDataProvider.cs
+++ b/GiftTasteHelper/Framework/Controllers/GiftDataProvider.cs
@@ -70,8 +70,7 @@ namespace GiftTasteHelper.Framework
     #region AllGiftDataProvider 
     internal class AllGiftDataProvider : BaseGiftDataProvider
     {
-        public AllGiftDataProvider(IGiftDatabase database)
-            : base(database)
+        public AllGiftDataProvider(IGiftDatabase database) : base(database)
         {
             var tasteTypes = Enum.GetValues(typeof(GiftTaste)).Cast<GiftTaste>().Where(val => val != GiftTaste.MAX);
             foreach (var giftTaste in Game1.NPCGiftTastes)

--- a/GiftTasteHelper/Framework/Controllers/GiftDataProvider.cs
+++ b/GiftTasteHelper/Framework/Controllers/GiftDataProvider.cs
@@ -18,9 +18,9 @@ namespace GiftTasteHelper.Framework
             this.Database.DatabaseChanged += () => DataSourceChanged?.Invoke();
         }
 
-        public virtual IEnumerable<int> GetGifts(string npcName, GiftTaste taste, bool includeUniversal)
+        public virtual IEnumerable<string> GetGifts(string npcName, GiftTaste taste, bool includeUniversal)
         {
-            IEnumerable<int> gifts = Database.GetGiftsForTaste(npcName, taste);
+            IEnumerable<string> gifts = Database.GetGiftsForTaste(npcName, taste);
             if (includeUniversal)
             {
                 // Individual NPC tastes may conflict with the universal ones.
@@ -29,7 +29,7 @@ namespace GiftTasteHelper.Framework
             return gifts;
         }
 
-        public virtual IEnumerable<int> GetUniversalGifts(string npcName, GiftTaste taste)
+        public virtual IEnumerable<string> GetUniversalGifts(string npcName, GiftTaste taste)
         {
             return Database.GetGiftsForTaste(Utils.UniversalTasteNames[taste], taste)
                 .Where(itemId => Utils.GetTasteForGift(npcName, itemId) == taste);
@@ -45,7 +45,7 @@ namespace GiftTasteHelper.Framework
         {
         }
 
-        public override IEnumerable<int> GetGifts(string npcName, GiftTaste taste, bool includeUniversal)
+        public override IEnumerable<string> GetGifts(string npcName, GiftTaste taste, bool includeUniversal)
         {
             // Universal gifts are stored with the regular ones in the DB so we need to remove them if they shouldn't be included.
             var gifts = base.GetGifts(npcName, taste, includeUniversal);
@@ -59,7 +59,7 @@ namespace GiftTasteHelper.Framework
             return gifts;
         }
 
-        public override IEnumerable<int> GetUniversalGifts(string npcName, GiftTaste taste)
+        public override IEnumerable<string> GetUniversalGifts(string npcName, GiftTaste taste)
         {
             var universal = Utils.GetItemsForTaste(Utils.UniversalTasteNames[taste], taste);
             return Database.GetGiftsForTaste(npcName, taste).Intersect(universal);

--- a/GiftTasteHelper/Framework/Controllers/GiftDatabase.cs
+++ b/GiftTasteHelper/Framework/Controllers/GiftDatabase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI;
 
@@ -25,7 +26,7 @@ namespace GiftTasteHelper.Framework
         }
 
         /// <summary>Returns if the database has an item for a particular NPC stored.</summary>
-        public bool ContainsGift(string npcName, int itemId, GiftTaste taste)
+        public bool ContainsGift(string npcName, string itemId, GiftTaste taste)
         {
             if (taste == GiftTaste.MAX)
             {
@@ -35,7 +36,7 @@ namespace GiftTasteHelper.Framework
         }
 
         /// <summary>Adds an item for an npc to the database.</summary>
-        public virtual bool AddGift(string npcName, int itemId, GiftTaste taste)
+        public virtual bool AddGift(string npcName, string itemId, GiftTaste taste)
         {
             if (taste == GiftTaste.MAX)
             {
@@ -61,7 +62,7 @@ namespace GiftTasteHelper.Framework
         }
 
         /// <summary>Adds a range of items for an npc to the database.</summary>
-        public virtual bool AddGifts(string npcName, GiftTaste taste, int[] itemIds)
+        public virtual bool AddGifts(string npcName, GiftTaste taste, string[] itemIds)
         {
             if (taste == GiftTaste.MAX)
             {
@@ -85,7 +86,7 @@ namespace GiftTasteHelper.Framework
         }
 
         /// <summary>Returns all the gifts of the given taste in the database for that npc.</summary>
-        public int[] GetGiftsForTaste(string npcName, GiftTaste taste)
+        public string[] GetGiftsForTaste(string npcName, GiftTaste taste)
         {
             if (Database.Entries.ContainsKey(npcName))
             {
@@ -95,7 +96,7 @@ namespace GiftTasteHelper.Framework
                     return entryForTaste.Select(model => model.ItemId).ToArray();
                 }
             }
-            return new int[] { };
+            return Array.Empty<string>();
         }
     }
 
@@ -164,7 +165,7 @@ namespace GiftTasteHelper.Framework
             newDb.Write();
         }
 
-        public override bool AddGift(string npcName, int itemId, GiftTaste taste)
+        public override bool AddGift(string npcName, string itemId, GiftTaste taste)
         {
             if (base.AddGift(npcName, itemId, taste))
             {
@@ -174,7 +175,7 @@ namespace GiftTasteHelper.Framework
             return false;
         }
 
-        public override bool AddGifts(string npcName, GiftTaste taste, int[] itemIds)
+        public override bool AddGifts(string npcName, GiftTaste taste, string[] itemIds)
         {
             if (base.AddGifts(npcName, taste, itemIds))
             {

--- a/GiftTasteHelper/Framework/Controllers/GiftDrawDataProvider.cs
+++ b/GiftTasteHelper/Framework/Controllers/GiftDrawDataProvider.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Xna.Framework;
 using StardewValley;
 
 namespace GiftTasteHelper.Framework
 {
     internal class GiftInfo
     {
+        public static readonly SVector2 IconSize = new (16, 16);
         public ItemData Item;
         public GiftTaste Taste;
         public bool Universal;
@@ -15,7 +15,6 @@ namespace GiftTasteHelper.Framework
 
     internal class GiftDrawData
     {
-        public Rectangle IconSize => this.Gifts.First().Item.TileSheetSourceRect;
         public string NpcName { get; }
         public GiftInfo[] Gifts;
 

--- a/GiftTasteHelper/Framework/Controllers/GiftMonitor.cs
+++ b/GiftTasteHelper/Framework/Controllers/GiftMonitor.cs
@@ -84,7 +84,7 @@ namespace GiftTasteHelper.Framework
                 }
 
                 this.PriorGiftsGiven = this.GiftsGiven;
-                var itemId = this.HeldGift.ParentSheetIndex;
+                var itemId = this.HeldGift.itemId.Value;
                 this.HeldGift = null;
 
                 if (Utils.Ensure(npcGivenTo != null, "NPC given to is null!"))

--- a/GiftTasteHelper/Framework/Controllers/IGiftDataProvider.cs
+++ b/GiftTasteHelper/Framework/Controllers/IGiftDataProvider.cs
@@ -12,12 +12,12 @@ namespace GiftTasteHelper.Framework
         /// <param name="taste">The taste of gifts to get.</param>
         /// <param name="includeUniversal">Should universal gifts be included.</param>
         /// <returns>A list of item/category Ids.</returns>
-        IEnumerable<int> GetGifts(string npcName, GiftTaste taste, bool includeUniversal = false);
+        IEnumerable<string> GetGifts(string npcName, GiftTaste taste, bool includeUniversal = false);
 
         /// <summary>Gets all the universal gifts of a particular taste for an npc.</summary>
         /// <param name="npcName">The name of the npc to fetch the info for.</param>
         /// <param name="taste">The taste of gifts to get.</param>
         /// <returns>A list of item/category Ids.</returns>
-        IEnumerable<int> GetUniversalGifts(string npcName, GiftTaste taste);
+        IEnumerable<string> GetUniversalGifts(string npcName, GiftTaste taste);
     }
 }

--- a/GiftTasteHelper/Framework/Controllers/IGiftDatabase.cs
+++ b/GiftTasteHelper/Framework/Controllers/IGiftDatabase.cs
@@ -6,9 +6,9 @@
     {
         event DataSourceChangedDelegate DatabaseChanged;
 
-        bool AddGift(string npcName, int itemId, GiftTaste taste);
-        bool AddGifts(string npcName, GiftTaste taste, int[] itemIds);
+        bool AddGift(string npcName, string itemId, GiftTaste taste);
+        bool AddGifts(string npcName, GiftTaste taste, string[] itemIds);
 
-        int[] GetGiftsForTaste(string npcName, GiftTaste taste);
+        string[] GetGiftsForTaste(string npcName, GiftTaste taste);
     }
 }

--- a/GiftTasteHelper/Framework/Controllers/IGiftMonitor.cs
+++ b/GiftTasteHelper/Framework/Controllers/IGiftMonitor.cs
@@ -3,7 +3,7 @@
     /// <summary>Delegate for the GiftGiven event.</summary>
     /// <param name="npc">Name of the NPC the gift was given to.</param>
     /// <param name="itemId">The item id (parentSheetIndex) of the item that was given.</param>
-    delegate void GiftGivenDelegate(string npc, int itemId);
+    delegate void GiftGivenDelegate(string npc, string itemId);
 
     /// <summary>Monitors and alerts when a gift is given to an npc.</summary>
     internal interface IGiftMonitor

--- a/GiftTasteHelper/Framework/Controllers/SocialPage.cs
+++ b/GiftTasteHelper/Framework/Controllers/SocialPage.cs
@@ -20,7 +20,6 @@ namespace GiftTasteHelper.Framework
         private IReflectionHelper Reflection;
 
         private List<ClickableTextureComponent> FriendSlots;
-        private List<object> Names; // Other player names are ints, NPC names are strings.
 
         private int FirstCharacterIndex;
         private SVector2 SlotBoundsOffset;
@@ -46,10 +45,9 @@ namespace GiftTasteHelper.Framework
         {
             this.NativeSocialPage = nativePage;
             this.FriendSlots = this.Reflection.GetField<List<ClickableTextureComponent>>(this.NativeSocialPage, "sprites").GetValue();
-            this.Names = this.Reflection.GetField<List<object>>(this.NativeSocialPage, "names").GetValue();
 
             // Find the first NPC character slot
-            this.FirstCharacterIndex = this.Names.FindIndex(obj => obj is string);
+            this.FirstCharacterIndex = this.NativeSocialPage.SocialEntries.FindIndex(entry => !entry.IsPlayer);
             if (this.FriendSlots.Count == 0)
             {
                 Utils.DebugLog("Failed to init SocialPage: No friend slots found.", LogLevel.Error);
@@ -99,9 +97,9 @@ namespace GiftTasteHelper.Framework
                 var friend = this.FriendSlots[i];
                 var bounds = this.MakeSlotBounds(friend);
 
-                if (bounds.Contains(mousePoint) && Utils.Ensure(i < this.Names.Count, "Name index out of range"))
+                if (bounds.Contains(mousePoint) && Utils.Ensure(i < this.NativeSocialPage.SocialEntries.Count, "Name index out of range"))
                 {
-                    hoveredFriendName = this.Names[i] as string;
+                    hoveredFriendName = this.NativeSocialPage.SocialEntries[i].InternalName;
                     break;
                 }
             }

--- a/GiftTasteHelper/Framework/Models/GiftDatabaseModel.cs
+++ b/GiftTasteHelper/Framework/Models/GiftDatabaseModel.cs
@@ -7,9 +7,9 @@ namespace GiftTasteHelper.Framework
     /// <summary>Model for a gift item.</summary>
     internal class GiftModel
     {
-        public int ItemId { get; set; }
+        public string ItemId { get; set; }
 
-        public static explicit operator int(GiftModel model)
+        public static explicit operator string(GiftModel model)
         {
             return model.ItemId;
         }
@@ -27,7 +27,7 @@ namespace GiftTasteHelper.Framework
             private set => Entries[taste] = value;
         }
 
-        public bool Contains(GiftTaste taste, int itemId)
+        public bool Contains(GiftTaste taste, string itemId)
         {
             return Entries.ContainsKey(taste) && Entries[taste].Any(model => model.ItemId == itemId);
         }

--- a/GiftTasteHelper/Framework/Utils.cs
+++ b/GiftTasteHelper/Framework/Utils.cs
@@ -113,30 +113,25 @@ namespace GiftTasteHelper.Framework
         public static string[] GetItemsForTaste(string npcName, GiftTaste taste)
         {
             Debug.Assert(taste != GiftTaste.MAX);
-            if (!Game1.NPCGiftTastes.ContainsKey(npcName))
+            if (npcName == null || !Game1.NPCGiftTastes.TryGetValue(npcName, out var giftTaste))
             {
                 return Array.Empty<string>();
             }
 
-            var giftTaste = Game1.NPCGiftTastes[npcName];
             if (UniversalTastes.ContainsKey(npcName))
             {
                 // Universal tastes are parsed differently
                 return giftTaste.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             }
 
-            string[] giftTastes = giftTaste.Split('/');
-            if (giftTastes.Length == 0)
-            {
-                return Array.Empty<string>();
-            }
-
             // See http://stardewvalleywiki.com/Modding:Gift_taste_data
             int tasteIndex = (int)taste + 1; // Enum value is the even number which is the dialogue, odd is the list of item refs.
-            if (giftTastes[tasteIndex].Length > 0)
+            string[] giftTastes = giftTaste.Split('/');
+            if (giftTastes.Length > tasteIndex && giftTastes[tasteIndex].Length > 0)
             {
                 return giftTastes[tasteIndex].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             }
+
             return Array.Empty<string>();
         }
 

--- a/GiftTasteHelper/Framework/Views/CalendarGiftHelper.cs
+++ b/GiftTasteHelper/Framework/Views/CalendarGiftHelper.cs
@@ -95,7 +95,7 @@ namespace GiftTasteHelper.Framework
             Debug.Assert(this.Calendar.IsOpen, "OnCursorMoved being called but the calendar isn't open");
 
             // This gets the scaled mouse position
-            SVector2 mouse = new SVector2(e.NewPosition.ScreenPixels.X, e.NewPosition.ScreenPixels.Y);
+            SVector2 mouse = GetAdjustedCursorPosition(e.NewPosition.ScreenPixels.X, e.NewPosition.ScreenPixels.Y);
 
             int hoveredDay = this.Calendar.GetHoveredDayIndex(mouse) + 1; // Days start at one
             if (hoveredDay == this.HoveredDay)

--- a/GiftTasteHelper/Framework/Views/GiftHelper.cs
+++ b/GiftTasteHelper/Framework/Views/GiftHelper.cs
@@ -236,7 +236,6 @@ namespace GiftTasteHelper.Framework
                 var texture = ItemRegistry.GetData(item.ID).GetTexture();
                 var tileSheetSourceRect = Game1.getSourceRectForStandardTileSheet(texture, item.SpriteIndex, GiftInfo.IconSize.XInt, GiftInfo.IconSize.YInt);
                 this.DrawText(TokenParser.ParseText(item.DisplayName), textOffset, textColor);
-                // TODO: Fails to draw non item textures (such as books)
                 this.DrawTexture(texture, spriteOffset, tileSheetSourceRect, spriteScale);
                 
 

--- a/GiftTasteHelper/Framework/Views/GiftHelper.cs
+++ b/GiftTasteHelper/Framework/Views/GiftHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -30,7 +29,7 @@ namespace GiftTasteHelper.Framework
         public bool IsInitialized { get; private set; }
         public bool IsOpen { get; private set; }
         public GiftHelperType GiftHelperType { get; }
-        public float ZoomLevel => 1.0f; // SMAPI's draw call will handle zoom
+        public float UiScale => 1; // SMAPI's draw call will handle scale
 
 
         /*********
@@ -161,7 +160,7 @@ namespace GiftTasteHelper.Framework
                 maxNameSize = Utils.CreateMax(maxNameSize, drawData.Gifts[i].Item.NameSize);
             }
 
-            float spriteScale = 2.0f * this.ZoomLevel; // 16x16 is pretty small
+            float spriteScale = 2.0f * this.UiScale; // 16x16 is pretty small
             SVector2 spriteSize = numItemsToDraw > 0 ? GiftInfo.IconSize : SVector2.Zero; // We just need the dimensions which we assume are all the same
             SVector2 scaledSpriteSize = spriteSize * spriteScale;
 
@@ -172,12 +171,12 @@ namespace GiftTasteHelper.Framework
             SVector2 mouse = new SVector2(Game1.getOldMouseX(), Game1.getOldMouseY());
 
             int padding = 4; // Chosen by fair dice roll
-            int rowHeight = (int)Math.Max(maxTextSize.Y * this.ZoomLevel, scaledSpriteSize.YInt) + padding;
-            int columnWidth = this.AdjustForTileSize((maxTextSize.X * this.ZoomLevel) + scaledSpriteSize.XInt) + padding;
-            int width = this.AdjustForTileSize((maxTextSize.X * this.ZoomLevel) + scaledSpriteSize.XInt) + padding;
+            int rowHeight = (int)Math.Max(maxTextSize.Y * this.UiScale, scaledSpriteSize.YInt) + padding;
+            int columnWidth = this.AdjustForTileSize((maxTextSize.X * this.UiScale) + scaledSpriteSize.XInt) + padding;
+            int width = this.AdjustForTileSize((maxTextSize.X * this.UiScale) + scaledSpriteSize.XInt) + padding;
             int height = this.AdjustForTileSize(rowHeight * (numItemsToDraw + 1)); // Add one to make room for the title
-            int x = this.AdjustForTileSize(mouse.X, 0.5f, this.ZoomLevel);
-            int y = this.AdjustForTileSize(mouse.Y, 0.5f, this.ZoomLevel);
+            int x = this.AdjustForTileSize(mouse.X, 0.5f, this.UiScale);
+            int y = this.AdjustForTileSize(mouse.Y, 0.5f, this.UiScale);
 
             int viewportW = (int)(Game1.viewport.Width * Game1.options.zoomLevel / Game1.options.uiScale);
             int viewportH = (int)(Game1.viewport.Height * Game1.options.zoomLevel / Game1.options.uiScale);
@@ -189,7 +188,7 @@ namespace GiftTasteHelper.Framework
                 height = this.AdjustForTileSize(rowHeight * (numItemsPerColumn + 1));
 
                 int columnsToDraw = (numItemsToDraw - 1) / numItemsPerColumn + 1;
-                width = (this.AdjustForTileSize((maxTextSize.X * this.ZoomLevel) + scaledSpriteSize.XInt) + padding) * columnsToDraw;
+                width = (this.AdjustForTileSize((maxTextSize.X * this.UiScale) + scaledSpriteSize.XInt) + padding) * columnsToDraw;
             }
 
             // Let derived classes adjust the positioning
@@ -198,7 +197,7 @@ namespace GiftTasteHelper.Framework
             // Approximate where the original tooltip will be positioned if there is an existing one we need to account for
             this.OrigHoverTextSize = SVector2.MeasureString(originalTooltipText, Game1.dialogueFont);
             int origTToffsetX = this.OrigHoverTextSize.X > 0
-                ? Math.Max(0, this.AdjustForTileSize(this.OrigHoverTextSize.X + mouse.X, 1.0f) - viewportW) + width
+                ? Math.Max(0, this.AdjustForTileSize(this.OrigHoverTextSize.X + mouse.X, this.UiScale) - viewportW) + width
                 : 0;
 
             // Consider the position of the original tooltip and ensure we don't cover it up
@@ -209,7 +208,7 @@ namespace GiftTasteHelper.Framework
 
             // Part of the spritesheet containing the texture we want to draw
             Rectangle menuTextureSourceRect = new Rectangle(0, 256, 60, 60);
-            IClickableMenu.drawTextureBox(spriteBatch, Game1.menuTexture, menuTextureSourceRect, tooltipPos.XInt, tooltipPos.YInt, width, height, Color.White, this.ZoomLevel);
+            IClickableMenu.drawTextureBox(spriteBatch, Game1.menuTexture, menuTextureSourceRect, tooltipPos.XInt, tooltipPos.YInt, width, height, Color.White, this.UiScale);
 
             // Offset the sprite from the corner of the bg, and the text to the right and centered vertically of the sprite
             SVector2 spriteOffset = new SVector2(this.AdjustForTileSize(tooltipPos.X, 0.25f), this.AdjustForTileSize(tooltipPos.Y, 0.25f));
@@ -274,7 +273,7 @@ namespace GiftTasteHelper.Framework
 
         private void DrawText(string text, SVector2 pos, Color textColor)
         {
-            Game1.spriteBatch.DrawString(Game1.smallFont, text, pos.ToVector2(), textColor, 0.0f, Vector2.Zero, this.ZoomLevel, SpriteEffects.None, 0.0f);
+            Game1.spriteBatch.DrawString(Game1.smallFont, text, pos.ToVector2(), textColor, 0.0f, Vector2.Zero, this.UiScale, SpriteEffects.None, 0.0f);
         }
 
         private void DrawTexture(Texture2D texture, SVector2 pos, Rectangle source, float scale = 1.0f)
@@ -315,6 +314,9 @@ namespace GiftTasteHelper.Framework
             return Math.Max(0, ca);
         }
         #endregion Drawing
+
+        protected static SVector2 GetAdjustedCursorPosition(float x, float y)
+            => new SVector2(x, y) * Game1.options.zoomLevel / Game1.options.uiScale;
     }
 
 }

--- a/GiftTasteHelper/Framework/Views/SocialPageGiftHelper.cs
+++ b/GiftTasteHelper/Framework/Views/SocialPageGiftHelper.cs
@@ -141,8 +141,5 @@ namespace GiftTasteHelper.Framework
             // Listening for when the slot index changes fixes this.
             UpdateHoveredNPC(GetAdjustedCursorPosition(Game1.getMouseX(), Game1.getMouseY()));
         }
-
-        private static SVector2 GetAdjustedCursorPosition(float x, float y)
-            => new SVector2(x, y) * Game1.options.zoomLevel / Game1.options.uiScale;
     }
 }

--- a/GiftTasteHelper/GiftTasteHelper.cs
+++ b/GiftTasteHelper/GiftTasteHelper.cs
@@ -44,7 +44,6 @@ namespace GiftTasteHelper
             helper.Events.GameLoop.DayStarted += this.OnDayStarted;
 
             InitDebugCommands(this.Helper);
-
             Startup();
         }
 
@@ -155,7 +154,7 @@ namespace GiftTasteHelper
         // Gift Monitor Handling
         // ===================================================================
 
-        private void OnGiftGiven(string npc, int itemId)
+        private void OnGiftGiven(string npc, string itemId)
         {
             var taste = Utils.GetTasteForGift(npc, itemId);
             if (taste != GiftTaste.MAX)
@@ -371,7 +370,7 @@ namespace GiftTasteHelper
                 }
                 Game1.warpFarmer(location, x / Game1.tileSize, y / Game1.tileSize, false);
             });
-
+            /*
             helper.ConsoleCommands.Add("setup", "", (name, args) =>
             {
                 helper.ConsoleCommands.Trigger("world_settime", new string[] { "1000" });
@@ -382,6 +381,7 @@ namespace GiftTasteHelper
                     helper.ConsoleCommands.Trigger("player_add", new string[] { "Object", item.ToString(), "10" });
                 }
             });
+            */
 #endif
         }
         #endregion

--- a/GiftTasteHelper/GiftTasteHelper.csproj
+++ b/GiftTasteHelper/GiftTasteHelper.csproj
@@ -1,81 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{CA415B12-5C37-487A-92BE-0AED14440F36}</ProjectGuid>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>GiftTasteHelper</RootNamespace>
-    <AssemblyName>GiftTasteHelper</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyTitle>CalendarBirthdayGiftHelper</AssemblyTitle>
+    <Product>CalendarBirthdayGiftHelper</Product>
+    <Copyright>Copyright ©  2016</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;WITH_LOGGING</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>..\bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Framework\Controllers\Calendar.cs" />
-    <Compile Include="Framework\Controllers\GiftDatabase.cs" />
-    <Compile Include="Framework\Controllers\GiftDataProvider.cs" />
-    <Compile Include="Framework\Controllers\GiftDrawDataProvider.cs" />
-    <Compile Include="Framework\Controllers\GiftMonitor.cs" />
-    <Compile Include="Framework\Controllers\IGiftDataProvider.cs" />
-    <Compile Include="Framework\Controllers\IGiftDatabase.cs" />
-    <Compile Include="Framework\Controllers\IGiftDrawDataProvider.cs" />
-    <Compile Include="Framework\Controllers\IGiftMonitor.cs" />
-    <Compile Include="Framework\Models\GiftConfig.cs" />
-    <Compile Include="Framework\Models\GiftDatabaseModel.cs" />
-    <Compile Include="Framework\GiftHelperTypes.cs" />
-    <Compile Include="GiftTasteHelper.cs" />
-    <Compile Include="Framework\Views\CalendarGiftHelper.cs" />
-    <Compile Include="Framework\Views\GiftHelper.cs" />
-    <Compile Include="Framework\Views\IGiftHelper.cs" />
-    <Compile Include="Framework\Models\ItemData.cs" />
-    <Compile Include="Framework\Models\ModConfig.cs" />
-    <Compile Include="Framework\Models\NPCGiftInfo.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Framework\Controllers\SocialPage.cs" />
-    <Compile Include="Framework\Views\SocialPageGiftHelper.cs" />
-    <Compile Include="Framework\SVector2.cs" />
-    <Compile Include="Framework\Utils.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="i18n\de.json" />
-    <None Include="i18n\default.json" />
-    <None Include="i18n\es.json" />
-    <None Include="i18n\ja.json" />
-    <None Include="i18n\ko.json" />
-    <None Include="i18n\pt.json" />
-    <None Include="i18n\ru.json" />
-    <None Include="i18n\th.json" />
-    <None Include="i18n\zh.json" />
-    <None Include="manifest.json" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GiftTasteHelper/Properties/AssemblyInfo.cs
+++ b/GiftTasteHelper/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/GiftTasteHelper/Properties/AssemblyInfo.cs
+++ b/GiftTasteHelper/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CalendarBirthdayGiftHelper")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CalendarBirthdayGiftHelper")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ca415b12-5c37-487a-92be-0aed14440f36")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GiftTasteHelper/manifest.json
+++ b/GiftTasteHelper/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Gift Taste Helper",
   "Author": "Isi0, tstaples (aka catman)",
-  "Version": "2.10.0",
+  "Version": "2.9.5-unofficial.2",
   "MinimumApiVersion": "4.0.0",
   "Description": "Displays NPC gift tastes in a handy tooltip.",
   "UniqueID": "Isi0.GiftTasteHelper",

--- a/GiftTasteHelper/manifest.json
+++ b/GiftTasteHelper/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Gift Taste Helper",
   "Author": "Isi0, tstaples (aka catman)",
-  "Version": "2.9.5-unofficial.2",
+  "Version": "2.9.6-unofficial.3",
   "MinimumApiVersion": "4.0.0",
   "Description": "Displays NPC gift tastes in a handy tooltip.",
   "UniqueID": "Isi0.GiftTasteHelper",

--- a/GiftTasteHelper/manifest.json
+++ b/GiftTasteHelper/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "Gift Taste Helper",
   "Author": "Isi0, tstaples (aka catman)",
-  "Version": "2.9.4",
-  "MinimumApiVersion": "3.18.6",
+  "Version": "2.10.0",
+  "MinimumApiVersion": "4.0.0",
   "Description": "Displays NPC gift tastes in a handy tooltip.",
   "UniqueID": "Isi0.GiftTasteHelper",
   "EntryDll": "GiftTasteHelper.dll",


### PR DESCRIPTION
Implements changes neccesary to migrate to Stardew Valley 1.6.

**Changes**
- Manifest version changed to 2.9.5-unofficial.2 (should be changed)
- Manifest minimum API version changed to 4.0.0
- Updated to .Net 6.0
- `int` ids changed to `string`
- Tokenized item display names for localization support
- Sprite sheets are now correctly selected depending on the item
- `SocialPage` reflection used to get private names field changed as they can now be publicly accessed through the `SocialEntries`
- `Utils.StringToIntArray` removed as it is no longer used
- `Game1.objectInformation` changed to use `Game1.objectData`

During my testing i have not encountered any issues, the icons and localized texts are displayed correctly. 